### PR TITLE
remove react as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "recast": "^0.10.12",
     "style-loader": "^0.11.0"
   },
-  "peerDependencies": {
-    "react": ">= 0.12.0"
-  },
   "devDependencies": {
     "bluebird": "^2.9.24",
     "jasmine-node": "^1.14.5",


### PR DESCRIPTION
Peerdeps r dum.

Can't use latest versions of react with this, and npm is still pretty silly when it comes to peer deps. Just removing it makes everything easier.