### PR TITLE
removed props from being added to the style tag

### DIFF
--- a/lib/makeStyleComponentClass.js
+++ b/lib/makeStyleComponentClass.js
@@ -24,6 +24,7 @@ function makeStyleComponentClass(defaults, displayName, tagName) {
         children: null,
         className: null,
         component: null,
+        props: null,
         style: null
       });
       assign(style, this.props.style);


### PR DESCRIPTION
If you add props to the final component you end up with a style tag of `props`:

`<Inline
   component="img"
   props={ src: 'pic.jpg' } />`

results in:

`<img src="pic.jpg" style="props: [object Object]"></img>`