### PR TITLE
spread `props` prop on to the rendered element

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -4,8 +4,9 @@ var Avatar = require('./Avatar');
 var {Block} = require('../lib/Display');
 var LayoutConstants = require('./LayoutConstants');
 var React = require('react');
+var ReactDOM = require('react-dom');
 
-React.render(
+ReactDOM.render(
   <Block
     marginLeft="auto"
     marginRight="auto"
@@ -13,7 +14,7 @@ React.render(
     border={'1px solid ' + LayoutConstants.secondaryColor}
     width={48 * LayoutConstants.gridUnit}
     minHeight={64}>
-    <Avatar username="pwh" />
+    <Avatar username="metallica" />
     <Avatar username="justintimberlake" />
     <Avatar username="carlyraejepsen" />
   </Block>,

--- a/lib/makeStyleComponentClass.js
+++ b/lib/makeStyleComponentClass.js
@@ -55,10 +55,10 @@ function makeStyleComponentClass(defaults, displayName, tagName) {
 
       return React.createElement(
         this.props.component || tagName,
-        {
+        assign({
           className: (this.props.className || '') + ' ' + className,
           children: this.props.children,
-        }
+        }, this.props.props)
       );
     }
   });

--- a/lib/makeStyleComponentClass.js
+++ b/lib/makeStyleComponentClass.js
@@ -11,7 +11,8 @@ function getStyleFromProps(props) {
     children: null,
     className: null,
     component: null,
-    style: null
+    style: null,
+    props: null
   });
   assign(style, props.style);
   return style;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jsx-loader": "^0.13.1",
     "jsxhint": "^0.14.0",
     "node-jsdom": "^3.1.5",
+    "react-dom": "^0.14.8",
     "webpack": "1.8.9"
   }
 }


### PR DESCRIPTION
this is related to #12, but I notice that doesn't work anymore since your recent refactor. this brings back said behaviour, allowing to attach stuff like event handlers, `data-*` attributes, etc onto the rendered element. further, it fixes(?) the previous bug, where `props` would become a style attribute with value `[object Object]`

I'm not sure how this affects the extraction scripts, etc :| happy to try and fix if I broke something.

[also installed/saved `react-dom` to dependencies, to prevent the `React.render` warning when running the example]

