### PR TITLE
SSR with GlobalStylesheets

### DIFF
--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -12,6 +12,8 @@ var stylesheetIdSeed = 0;
 
 var styles = {};
 
+var browser = typeof document !== 'undefined';
+
 function addStyle(css){
   const head = document.head || document.getElementsByTagName('head')[0];
   const style = document.createElement('style');
@@ -43,7 +45,9 @@ function createStylesheet(stylesheet) {
 function reap() {
   for (var key in styles) {
     if (styles[key].refs === 0) {
-      styles[key].domNode.remove();
+      if (styles[key].domNode) {
+        styles[key].domNode.remove();
+      }
       delete styles[key];
     }
   }
@@ -51,7 +55,9 @@ function reap() {
 
 var GlobalStylesheets = {
   install: function() {
-    setInterval(reap, 10000);
+    if (browser) {
+      setInterval(reap, 10000);
+    }
   },
 
   getKey: function(styleObj) {
@@ -73,8 +79,10 @@ var GlobalStylesheets = {
         style: styleObj,
         refs: 0,
       };
-      stylesheet.domNode = createStylesheet(stylesheet);
-      document.head.appendChild(stylesheet.domNode);
+      if (browser) {
+        stylesheet.domNode = createStylesheet(stylesheet);
+        document.head.appendChild(stylesheet.domNode);
+      }
       styles[key] = stylesheet;
 
       stylesheetIdSeed++;


### PR DESCRIPTION
This is a PR against HEAD, **not** the npm published version (0.0.18 at time of writing).

When rendering style components server-side, jsxstyle is gets tripped up by the fact that `document` is undefined. This PR simply declines to do the DOM-bound things (like creating a `<style>` DOM node or reaping styles from the node) in `GlobalStylesheets`.

I can't tell for sure if this is *actually* a fix or just user error, but my end goal is an extracted stylesheet on the server, and as a part of that goal, i need to render my components with the correct class names, etc. Let me know if i'm barking up the wrong tree here!