### PR TITLE
Switch const to var

### DIFF
--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -13,8 +13,8 @@ var stylesheetIdSeed = 0;
 var styles = {};
 
 function addStyle(css){
-  const head = document.head || document.getElementsByTagName('head')[0];
-  const style = document.createElement('style');
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
 
   style.type = 'text/css';
   if (style.styleSheet){


### PR DESCRIPTION
Using const without webpack breaks pretty much every browser except latest Chrome.
