### PR TITLE
Avoid renderToStaticMarkup deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "style-loader": "^0.11.0"
   },
   "peerDependencies": {
-    "react": ">= 0.14.0"
+    "react": ">= 0.14.0",
+    "react-dom": ">= 0.14.0"
   },
   "devDependencies": {
     "bluebird": "^2.9.24",

--- a/tests/className.spec.js
+++ b/tests/className.spec.js
@@ -2,10 +2,11 @@
 
 var Inline = require('../Inline');
 var React = require('react');
+var ReactDOMServer = require('react-dom/server');
 
 describe('className', function() {
   it('works', function() {
-    var markup = React.renderToStaticMarkup(
+    var markup = ReactDOMServer.renderToStaticMarkup(
       React.createElement(Inline, {className: 'bla', color: 'red'}, 'honk')
     );
     expect(markup).toBe('<div style="color:red;display:inline;" class="bla">honk</div>');

--- a/tests/curry.spec.js
+++ b/tests/curry.spec.js
@@ -2,13 +2,14 @@
 
 var Inline = require('../Inline');
 var React = require('react');
+var ReactDOMServer = require('react-dom/server');
 var curry = require('../curry');
 
 describe('curry', function() {
   it('works', function() {
     var StandardText = curry(Inline, {color: 'gray', fontSize: 12});
     var EmphText = curry(Inline, {fontWeight: 'bold', color: 'black'});
-    var markup = React.renderToStaticMarkup(
+    var markup = ReactDOMServer.renderToStaticMarkup(
       React.createElement(
         'div', null,
         React.createElement(StandardText, null, 'hello world'),


### PR DESCRIPTION
Use the `react-dom` package to avoid a deprecation warning on React 0.14.8