### PR TITLE
WIP Basic Pseudo Selector Support

### DIFF
--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
+var explodePseudoStyles = require('./explodePseudoStyles');
 
 var assign = require('object-assign');
 var autoprefix = require('./autoprefix');
@@ -29,65 +30,21 @@ function addStyle(css){
 }
 
 function createStylesheet(stylesheet) {
-  var style = assign({}, stylesheet.style);
-  var hoverStyles = {};
-  var activeStyles = {};
-  var focusStyles = {};
+  var styles = explodePseudoStyles(assign({}, stylesheet.style))
+  var stylesheetText = '';
 
-  Object.keys(style).forEach(function(key) {
-    if (key.indexOf('hover') === 0) {
-      // Strip the key of the pseudo selector prefix and transform first char
-      // to lowercase to ensure correct markup generation and autoprefixing
-      var prop = key.substr(5);
-      hoverStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[key];
-      // Remove the key from main style entry
-      delete style[key];
+  for (var key in styles) {
+    if (styles.hasOwnProperty(key)) {
+      if (styles[key]) {
+        // Only print ':<pseudo>' when necessary
+        var pseudoSelector = key.startsWith('base') ? '' : ':' + key;
+        stylesheetText+= (
+          '\n.' + PREFIX + stylesheet.id + pseudoSelector +' {\n' +
+            CSSPropertyOperations.createMarkupForStyles(autoprefix(styles[key])) +
+            '\n}\n'
+        );
+      }
     }
-    if (key.indexOf('focus') === 0) {
-      var prop = key.substr(5);
-      focusStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[key];
-      delete style[key];
-    }
-    if (key.indexOf('active') === 0) {
-      var prop = key.substr(6);
-      activeStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[key];
-      delete style[key];
-    }
-  });
-
-  autoprefix(style);
-  var stylesheetText = (
-    '\n.' + PREFIX + stylesheet.id + ' {\n' +
-      CSSPropertyOperations.createMarkupForStyles(style) +
-      '\n}\n'
-  );
-
-  // Generate CSS for any pseudo selector props
-  if (Object.keys(hoverStyles).length > 0) {
-    autoprefix(hoverStyles)
-    stylesheetText += (
-      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
-        CSSPropertyOperations.createMarkupForStyles(hoverStyles) +
-        '\n}\n'
-    )
-  }
-
-  if (Object.keys(focusStyles).length > 0) {
-    autoprefix(focusStyles)
-    stylesheetText += (
-      '\n.' + PREFIX + stylesheet.id + ':focus {\n' +
-        CSSPropertyOperations.createMarkupForStyles(focusStyles) +
-        '\n}\n'
-    )
-  }
-
-  if (Object.keys(activeStyles).length > 0) {
-    autoprefix(activeStyles)
-    stylesheetText += (
-      '\n.' + PREFIX + stylesheet.id + ':active {\n' +
-        CSSPropertyOperations.createMarkupForStyles(activeStyles) +
-        '\n}\n'
-    )
   }
 
   return addStyle(stylesheetText);

--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -75,7 +75,7 @@ function createStylesheet(stylesheet) {
   if (Object.keys(focusStyles).length > 0) {
     autoprefix(focusStyles)
     stylesheetText += (
-      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+      '\n.' + PREFIX + stylesheet.id + ':focus \n' +
         CSSPropertyOperations.createMarkupForStyles(focusStyles) +
         '\n}\n'
     )
@@ -84,7 +84,7 @@ function createStylesheet(stylesheet) {
   if (Object.keys(activeStyles).length > 0) {
     autoprefix(activeStyles)
     stylesheetText += (
-      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+      '\n.' + PREFIX + stylesheet.id + ':active {\n' +
         CSSPropertyOperations.createMarkupForStyles(activeStyles) +
         '\n}\n'
     )

--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -30,12 +30,65 @@ function addStyle(css){
 
 function createStylesheet(stylesheet) {
   var style = assign({}, stylesheet.style);
+  var hoverStyles = {};
+  var activeStyles = {};
+  var focusStyles = {};
+
+  Object.keys(style).forEach(function(key) {
+    if (key.indexOf('hover') === 0) {
+      // Strip the key of the pseudo selector prefix and transform first char
+      // to lowercase to ensure correct markup generation and autoprefixing
+      var prop = key.substr(5);
+      hoverStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[key];
+      // Remove the key from main style entry
+      delete style[key];
+    }
+    if (key.indexOf('focus') === 0) {
+      var prop = key.substr(5);
+      focusStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[key];
+      delete style[key];
+    }
+    if (key.indexOf('active') === 0) {
+      var prop = key.substr(6);
+      activeStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[key];
+      delete style[key];
+    }
+  });
+
   autoprefix(style);
   var stylesheetText = (
     '\n.' + PREFIX + stylesheet.id + ' {\n' +
       CSSPropertyOperations.createMarkupForStyles(style) +
       '\n}\n'
   );
+
+  // Generate CSS for any pseudo selector props
+  if (Object.keys(hoverStyles).length > 0) {
+    autoprefix(hoverStyles)
+    stylesheetText += (
+      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+        CSSPropertyOperations.createMarkupForStyles(hoverStyles) +
+        '\n}\n'
+    )
+  }
+
+  if (Object.keys(focusStyles).length > 0) {
+    autoprefix(focusStyles)
+    stylesheetText += (
+      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+        CSSPropertyOperations.createMarkupForStyles(focusStyles) +
+        '\n}\n'
+    )
+  }
+
+  if (Object.keys(activeStyles).length > 0) {
+    autoprefix(activeStyles)
+    stylesheetText += (
+      '\n.' + PREFIX + stylesheet.id + ':hover {\n' +
+        CSSPropertyOperations.createMarkupForStyles(activeStyles) +
+        '\n}\n'
+    )
+  }
 
   return addStyle(stylesheetText);
 }

--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -75,7 +75,7 @@ function createStylesheet(stylesheet) {
   if (Object.keys(focusStyles).length > 0) {
     autoprefix(focusStyles)
     stylesheetText += (
-      '\n.' + PREFIX + stylesheet.id + ':focus \n' +
+      '\n.' + PREFIX + stylesheet.id + ':focus {\n' +
         CSSPropertyOperations.createMarkupForStyles(focusStyles) +
         '\n}\n'
     )

--- a/lib/GlobalStylesheets.js
+++ b/lib/GlobalStylesheets.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
 var explodePseudoStyles = require('./explodePseudoStyles');
+var createCSS = require('./createCSS');
 
 var assign = require('object-assign');
-var autoprefix = require('./autoprefix');
 var invariant = require('invariant');
 
 var PREFIX = 'jsxstyle';
@@ -30,22 +29,14 @@ function addStyle(css){
 }
 
 function createStylesheet(stylesheet) {
-  var styles = explodePseudoStyles(assign({}, stylesheet.style))
-  var stylesheetText = '';
-
-  for (var key in styles) {
-    if (styles.hasOwnProperty(key)) {
-      if (styles[key]) {
-        // Only print ':<pseudo>' when necessary
-        var pseudoSelector = key.startsWith('base') ? '' : ':' + key;
-        stylesheetText+= (
-          '\n.' + PREFIX + stylesheet.id + pseudoSelector +' {\n' +
-            CSSPropertyOperations.createMarkupForStyles(autoprefix(styles[key])) +
-            '\n}\n'
-        );
-      }
-    }
-  }
+  var styles = explodePseudoStyles(assign({}, stylesheet.style));
+  var className = PREFIX + stylesheet.id;
+  var stylesheetText = [
+    createCSS(styles.base, className, null),
+    createCSS(styles.hover, className, null, ':hover'),
+    createCSS(styles.active, className, null, ':active'),
+    createCSS(styles.focus, className, null, ':focus')
+  ].join('');
 
   return addStyle(stylesheetText);
 }

--- a/lib/createCSS.js
+++ b/lib/createCSS.js
@@ -8,25 +8,15 @@ function createCSS(styles, className, comment, pseudoSelector) {
     return null;
   }
   pseudoSelector = pseudoSelector || '';
-  if (comment) {
-    // pretty print if comment
-    return (
-      '\n.' + className + pseudoSelector + ' {\n' +
-      comment +
-      CSSPropertyOperations.createMarkupForStyles(
-        autoprefix(styles)
-      ).split(';').join(';\n  ').trim() +
-      '\n}\n\n'
-    );
-  }
-  else {
-    // almost-minify
-    return (
-      '\n.' + className + pseudoSelector + ' {\n' +
-      CSSPropertyOperations.createMarkupForStyles(autoprefix(styles)) +
-      '\n}\n'
-    );
-  }
+  comment = comment || '';
+  return (
+    '.' + className + pseudoSelector + ' {\n' +
+    '  ' + comment +
+    CSSPropertyOperations.createMarkupForStyles(
+      autoprefix(styles)
+    ).split(';').join(';\n  ').trim() +
+    '\n}\n\n'
+  );
 }
 
 module.exports = createCSS;

--- a/lib/createCSS.js
+++ b/lib/createCSS.js
@@ -1,0 +1,32 @@
+'use strict'
+
+var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
+var autoprefix = require('./autoprefix');
+
+function createCSS(styles, className, comment, pseudoSelector) {
+  if (!styles) {
+    return null;
+  }
+  pseudoSelector = pseudoSelector || '';
+  if (comment) {
+    // pretty print if comment
+    return (
+      '\n.' + className + pseudoSelector + ' {\n' +
+      comment +
+      CSSPropertyOperations.createMarkupForStyles(
+        autoprefix(styles)
+      ).split(';').join(';\n  ').trim() +
+      '\n}\n\n'
+    );
+  }
+  else {
+    // almost-minify
+    return (
+      '\n.' + className + pseudoSelector + ' {\n' +
+      CSSPropertyOperations.createMarkupForStyles(autoprefix(styles)) +
+      '\n}\n'
+    );
+  }
+}
+
+module.exports = createCSS;

--- a/lib/explodePseudoStyles.js
+++ b/lib/explodePseudoStyles.js
@@ -4,6 +4,7 @@ function explodePseudoStyles(style) {
   var hoverStyles = null;
   var activeStyles = null;
   var focusStyles = null;
+  var baseStyles = null;
 
   for (var name in style) {
     if (style.hasOwnProperty(name) ) {
@@ -13,24 +14,23 @@ function explodePseudoStyles(style) {
         // to lowercase to ensure correct markup generation and autoprefixing
         var prop = name.substr(5);
         hoverStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[name];
-        // Remove the key from main style entry
-        delete style[name];
       } else if (name.startsWith('focus')) {
         focusStyles = focusStyles || {};
         var prop = name.substr(5);
         focusStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[name];
-        delete style[name];
       } else if (name.startsWith('active')) {
         activeStyles = activeStyles || {};
         var prop = name.substr(6);
         activeStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[name];
-        delete style[name];
+      } else {
+        baseStyles = baseStyles || {};
+        baseStyles[name] = style[name];
       }
     }
   }
 
   return {
-    base: style,
+    base: baseStyles,
     hover: hoverStyles,
     focus: focusStyles,
     active: activeStyles

--- a/lib/explodePseudoStyles.js
+++ b/lib/explodePseudoStyles.js
@@ -1,0 +1,40 @@
+'use strict'
+
+function explodePseudoStyles(style) {
+  var hoverStyles = null;
+  var activeStyles = null;
+  var focusStyles = null;
+
+  for (var name in style) {
+    if (style.hasOwnProperty(name) ) {
+      if (name.startsWith('hover')) {
+        hoverStyles = hoverStyles || {};
+        // Strip the name of the pseudo selector prefix and transform first char
+        // to lowercase to ensure correct markup generation and autoprefixing
+        var prop = name.substr(5);
+        hoverStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[name];
+        // Remove the key from main style entry
+        delete style[name];
+      } else if (name.startsWith('focus')) {
+        focusStyles = focusStyles || {};
+        var prop = name.substr(5);
+        focusStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[name];
+        delete style[name];
+      } else if (name.startsWith('active')) {
+        activeStyles = activeStyles || {};
+        var prop = name.substr(6);
+        activeStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = style[name];
+        delete style[name];
+      }
+    }
+  }
+
+  return {
+    base: style,
+    hover: hoverStyles,
+    focus: focusStyles,
+    active: activeStyles
+  };
+}
+
+module.exports = explodePseudoStyles;

--- a/lib/extractStyles.js
+++ b/lib/extractStyles.js
@@ -2,6 +2,7 @@
 
 var CSSDisplayNames = require('./CSSDisplayNames');
 var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
+var explodePseudoStyles = require('./explodePseudoStyles')
 
 var assign = require('object-assign');
 var autoprefix = require('./autoprefix');
@@ -145,74 +146,23 @@ function extractStyles(src, staticNamespace, getClassNameAndComment) {
       classNameAndComment.comment ? '/* ' + classNameAndComment.comment + ' */\n  ' : ''
     );
 
-    var hoverStyles = {};
-    var focusStyles = {};
-    var activeStyles = {};
+    var explodedStyles = explodePseudoStyles(entry.staticAttributes);
 
-    // Check entry for any props with pseudo selector prefixes, move them to
-    // respective pseudo style object
-    Object.keys(entry.staticAttributes).forEach(function(key) {
-      if (key.indexOf('hover') === 0) {
-        // Strip the key of the pseudo selector prefix and transform first char
-        // to lowercase to ensure correct markup generation and autoprefixing
-        var prop = key.substr(5);
-        hoverStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = entry.staticAttributes[key];
-        // Remove the key from main style entry
-        delete entry.staticAttributes[key];
+    for (var key in explodedStyles) {
+      if (explodedStyles.hasOwnProperty(key)) {
+        if (explodedStyles[key]) {
+          // Only print ':<pseudo>' when necessary
+          var pseudoSelector = key.startsWith('base') ? '' : ':' + key;
+          css += (
+            '.' + className + ' {\n  ' +
+              comment +
+              CSSPropertyOperations.createMarkupForStyles(
+                autoprefix(explodedStyles[key])
+              ).split(';').join(';\n  ').trim() +
+              '\n}\n\n'
+          );
+        }
       }
-      if (key.indexOf('focus') === 0) {
-        var prop = key.substr(5);
-        focusStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = entry.staticAttributes[key];
-        delete entry.staticAttributes[key];
-      }
-      if (key.indexOf('active') === 0) {
-        var prop = key.substr(6);
-        activeStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = entry.staticAttributes[key];
-        delete entry.staticAttributes[key];
-      }
-    });
-
-    css += (
-      '.' + className + ' {\n  ' +
-        comment +
-        CSSPropertyOperations.createMarkupForStyles(
-          autoprefix(entry.staticAttributes)
-        ).split(';').join(';\n  ').trim() +
-        '\n}\n\n'
-    );
-
-    // Generate CSS for any pseudo selector props
-    if (Object.keys(hoverStyles).length > 0) {
-      css += (
-        '.' + className + ':hover {\n  ' +
-          comment +
-          CSSPropertyOperations.createMarkupForStyles(
-            autoprefix(hoverStyles)
-          ).split(';').join(';\n  ').trim() +
-          '\n}\n\n'
-      )
-    }
-
-    if (Object.keys(focusStyles).length > 0) {
-      css += (
-        '.' + className + ':focus {\n  ' +
-          comment +
-          CSSPropertyOperations.createMarkupForStyles(
-            autoprefix(focusStyles)
-          ).split(';').join(';\n  ').trim() +
-          '\n}\n\n'
-      )
-    }
-
-    if (Object.keys(focusStyles).length > 0) {
-      css += (
-        '.' + className + ':active {\n  ' +
-          comment +
-          CSSPropertyOperations.createMarkupForStyles(
-            autoprefix(activeStyles)
-          ).split(';').join(';\n  ').trim() +
-          '\n}\n\n'
-      )
     }
   });
 

--- a/lib/extractStyles.js
+++ b/lib/extractStyles.js
@@ -144,6 +144,34 @@ function extractStyles(src, staticNamespace, getClassNameAndComment) {
     var comment = (
       classNameAndComment.comment ? '/* ' + classNameAndComment.comment + ' */\n  ' : ''
     );
+
+    var hoverStyles = {};
+    var focusStyles = {};
+    var activeStyles = {};
+
+    // Check entry for any props with pseudo selector prefixes, move them to
+    // respective pseudo style object
+    Object.keys(entry.staticAttributes).forEach(function(key) {
+      if (key.indexOf('hover') === 0) {
+        // Strip the key of the pseudo selector prefix and transform first char
+        // to lowercase to ensure correct markup generation and autoprefixing
+        var prop = key.substr(5);
+        hoverStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = entry.staticAttributes[key];
+        // Remove the key from main style entry
+        delete entry.staticAttributes[key];
+      }
+      if (key.indexOf('focus') === 0) {
+        var prop = key.substr(5);
+        focusStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = entry.staticAttributes[key];
+        delete entry.staticAttributes[key];
+      }
+      if (key.indexOf('active') === 0) {
+        var prop = key.substr(6);
+        activeStyles[prop.charAt(0).toLowerCase() + prop.slice(1)] = entry.staticAttributes[key];
+        delete entry.staticAttributes[key];
+      }
+    });
+
     css += (
       '.' + className + ' {\n  ' +
         comment +
@@ -152,6 +180,40 @@ function extractStyles(src, staticNamespace, getClassNameAndComment) {
         ).split(';').join(';\n  ').trim() +
         '\n}\n\n'
     );
+
+    // Generate CSS for any pseudo selector props
+    if (Object.keys(hoverStyles).length > 0) {
+      css += (
+        '.' + className + ':hover {\n  ' +
+          comment +
+          CSSPropertyOperations.createMarkupForStyles(
+            autoprefix(hoverStyles)
+          ).split(';').join(';\n  ').trim() +
+          '\n}\n\n'
+      )
+    }
+
+    if (Object.keys(focusStyles).length > 0) {
+      css += (
+        '.' + className + ':focus {\n  ' +
+          comment +
+          CSSPropertyOperations.createMarkupForStyles(
+            autoprefix(focusStyles)
+          ).split(';').join(';\n  ').trim() +
+          '\n}\n\n'
+      )
+    }
+
+    if (Object.keys(focusStyles).length > 0) {
+      css += (
+        '.' + className + ':active {\n  ' +
+          comment +
+          CSSPropertyOperations.createMarkupForStyles(
+            autoprefix(activeStyles)
+          ).split(';').join(';\n  ').trim() +
+          '\n}\n\n'
+      )
+    }
   });
 
   evalContext.dispose();

--- a/lib/extractStyles.js
+++ b/lib/extractStyles.js
@@ -1,11 +1,10 @@
 'use strict';
 
 var CSSDisplayNames = require('./CSSDisplayNames');
-var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
-var explodePseudoStyles = require('./explodePseudoStyles')
+var explodePseudoStyles = require('./explodePseudoStyles');
+var createCSS = require('./createCSS');
 
 var assign = require('object-assign');
-var autoprefix = require('./autoprefix');
 var contextify = require('contextify');
 var invariant = require('invariant');
 var recast = require('recast');
@@ -148,22 +147,12 @@ function extractStyles(src, staticNamespace, getClassNameAndComment) {
 
     var explodedStyles = explodePseudoStyles(entry.staticAttributes);
 
-    for (var key in explodedStyles) {
-      if (explodedStyles.hasOwnProperty(key)) {
-        if (explodedStyles[key]) {
-          // Only print ':<pseudo>' when necessary
-          var pseudoSelector = key.startsWith('base') ? '' : ':' + key;
-          css += (
-            '.' + className + ' {\n  ' +
-              comment +
-              CSSPropertyOperations.createMarkupForStyles(
-                autoprefix(explodedStyles[key])
-              ).split(';').join(';\n  ').trim() +
-              '\n}\n\n'
-          );
-        }
-      }
-    }
+    css += [
+      createCSS(explodedStyles.base, className, comment, null),
+      createCSS(explodedStyles.hover, className, comment, ':hover'),
+      createCSS(explodedStyles.active, className, comment, ':active'),
+      createCSS(explodedStyles.focus, className, comment, ':focus')
+    ].join('');
   });
 
   evalContext.dispose();

--- a/tests/example.js
+++ b/tests/example.js
@@ -1,5 +1,5 @@
 var React = require('react');
-<Block width="100%" height={25} left={2 * LayoutConstants.x}>
+<Block width="100%" height={25} left={2 * LayoutConstants.x} hoverColor="blue" hoverBackgroundColor="white">
   <InlineBlock height={24} />
   <div style={{width: 10}} />
   <OtherComponent height={25} />

--- a/tests/extractStyles.spec.js
+++ b/tests/extractStyles.spec.js
@@ -11,7 +11,7 @@ describe('extractStyles', function() {
     var rv = extractStyles(EXAMPLE_SRC);
     expect(rv).toEqual({
       js: "var React = require('react');\n<div\n  style={{\n    \"left\": 2 * LayoutConstants.x\n  }}\n  className=\"__s_0\">\n  <div className=\"__s_1\" />\n  <div style={{width: 10}} />\n  <OtherComponent height={25} />\n</div>\n",
-      css: ".__s_0 {\n  width:100%;\n  height:25px;\n  display:block;\n}\n\n.__s_1 {\n  height:24px;\n  display:inline-block;\n}\n\n"
+      css: ".__s_0 {\n  width:100%;\n  height:25px;\n  display:block;\n}\n\n.__s_0:hover {\n  color:blue;\n  background-color:white;\n}\n\n.__s_1 {\n  height:24px;\n  display:inline-block;\n}\n\n"
     });
   });
 
@@ -19,7 +19,7 @@ describe('extractStyles', function() {
     var rv = extractStyles(EXAMPLE_SRC, {LayoutConstants: {x: 10}});
     expect(rv).toEqual({
       js: "var React = require('react');\n<div className=\"__s_0\">\n  <div className=\"__s_1\" />\n  <div style={{width: 10}} />\n  <OtherComponent height={25} />\n</div>\n",
-      css: ".__s_0 {\n  width:100%;\n  height:25px;\n  left:20px;\n  display:block;\n}\n\n.__s_1 {\n  height:24px;\n  display:inline-block;\n}\n\n"
+      css: ".__s_0 {\n  width:100%;\n  height:25px;\n  left:20px;\n  display:block;\n}\n\n.__s_0:hover {\n  color:blue;\n  background-color:white;\n}\n\n.__s_1 {\n  height:24px;\n  display:inline-block;\n}\n\n"
     });
   });
 
@@ -33,7 +33,7 @@ describe('extractStyles', function() {
     });
     expect(rv).toEqual({
       js: "var React = require('react');\n<div className=\"example_line2\">\n  <div className=\"example_line3\" />\n  <div style={{width: 10}} />\n  <OtherComponent height={25} />\n</div>\n",
-      css: ".example_line2 {\n  /* example.js:2 */\n  width:100%;\n  height:25px;\n  left:20px;\n  display:block;\n}\n\n.example_line3 {\n  /* example.js:3 */\n  height:24px;\n  display:inline-block;\n}\n\n"
+      css: ".example_line2 {\n  /* example.js:2 */\n  width:100%;\n  height:25px;\n  left:20px;\n  display:block;\n}\n\n.example_line2:hover {\n  /* example.js:2 */\n  color:blue;\n  background-color:white;\n}\n\n.example_line3 {\n  /* example.js:3 */\n  height:24px;\n  display:inline-block;\n}\n\n"
     });
   });
 });


### PR DESCRIPTION
This adds support for pseudo selectors `hover`, `focus`, and `active` by
looking for specially prefixed props.

## Simple Usage:

```javascript
// component.js
<Flex color="red" marginTop={2 * Styles.y} hoverColor="blue" hoverMarginTop={4 * Styles.y} />
```

```css
/* extracted css */
.f12345_0 {
  color: red;
  margin-top: 20px;
}
.f12345_0:hover {
  color: blue;
  margin-top: 40px;
}
```

### To Do's: 

- [ ] Update docs and example


