### PR TITLE
Replace contextify with vm

### DIFF
--- a/lib/extractStyles.js
+++ b/lib/extractStyles.js
@@ -5,7 +5,7 @@ var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
 
 var assign = require('object-assign');
 var autoprefix = require('./autoprefix');
-var contextify = require('contextify');
+var vm = require('vm');
 var invariant = require('invariant');
 var recast = require('recast');
 var types = recast.types;
@@ -46,10 +46,9 @@ function extractStyles(src, staticNamespace, getClassNameAndComment) {
   invariant(typeof getClassNameAndComment === 'function', 'getClassNameAndComment must be a function');
   invariant(typeof staticNamespace === 'object', 'staticNamespace must be an object');
 
-  var evalContext = assign({}, staticNamespace);
-  contextify(evalContext);
+  var evalContext = vm.createContext(assign({}, staticNamespace));
   function evaluate(exprNode) {
-    return evalContext.run(recast.print(exprNode).code);
+    return vm.runInContext(recast.print(exprNode).code, evalContext);
   }
 
   var ast = recast.parse(src);
@@ -153,8 +152,6 @@ function extractStyles(src, staticNamespace, getClassNameAndComment) {
         '\n}\n\n'
     );
   });
-
-  evalContext.dispose();
 
   return {
     js: recast.print(ast).code,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "contextify": "^0.1.13",
     "invariant": "^2.0.0",
     "loader-utils": "^0.2.7",
     "object-assign": "^2.0.0",


### PR DESCRIPTION
`contextify` is deprecated in Node >= 0.12.

Instead, the `vm` module offers the ability to [run code in context](https://nodejs.org/api/vm.html#vm_vm_runincontext_code_contextifiedsandbox_options).

Replacing this dependency removes the need to build a `contextify` binary, which makes it [a pain for lots of folks](https://github.com/brianmcd/contextify/issues).

Note: I ran into this issue while running macOS Sierra beta (10.12), but my current fix worked on both 10.11 and 10.12, using Node 0.12.7 and 5.6.0.